### PR TITLE
fix: Clean nightly process

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -134,126 +134,40 @@ jobs:
                contents: write     # Required for creating/updating releases
           steps:
                - name: Checkout repository
-                 uses: actions/checkout@v4.2.2
+                 uses: actions/checkout@v6.0.1
 
                - name: Download all artifacts
-                 uses: actions/download-artifact@v4.3.0
+                 uses: actions/download-artifact@v7.0.0
                  with:
                     path: artifacts
                     
-               - name: Install dependencies
-                 run: npm install mime-types
-
-               - name: Get commit details
-                 id: commit-details
+               - name: Prepare assets
                  run: |
-                   echo "message=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
-               - name: Create or update nightly release
-                 uses: actions/github-script@v7.0.1
+                   mkdir -p release_assets
+                   find artifacts -type f | while read -r file; do
+                     # Extract platform from artifact name (e.g. Blink-ubuntu-22.04-devSHA)
+                     artifact_name=$(echo "$file" | cut -d'/' -f2)
+                     platform=$(echo "$artifact_name" | sed -E 's/Blink-(.*)-dev.*/\1/' | sed 's/-/_/g')
+                     filename=$(basename "$file")
+                     cp "$file" "release_assets/${platform}-${filename}"
+                   done
+
+               - name: Delete old nightly release
+                 run: gh release delete nightly --yes --repo ${{ github.repository }} || true
                  env:
-                    COMMIT_MESSAGE: ${{ steps.commit-details.outputs.message }}
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+               - name: Create nightly release
+                 uses: softprops/action-gh-release@v2.5.0
                  with:
-                    github-token: ${{ secrets.GITHUB_TOKEN }}
-                    script: |
-                      const fs = require('fs');
-                      const path = require('path');
+                    tag_name: nightly
+                    name: Nightly Build (${{ github.sha }})
+                    body: |
+                      Nightly build from the latest main branch.
                       
-                      // Get today's date in YYYY-MM-DD format
-                      const today = new Date().toISOString().split('T')[0];
-                      const releaseTag = 'nightly';
-                      const releaseName = `Nightly Build (${today})`;
-                      
-                      // Check if nightly release already exists
-                      console.log("Checking for existing nightly release...");
-                      let release;
-                      try {
-                        release = await github.rest.repos.getReleaseByTag({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          tag: releaseTag
-                        });
-                        console.log("Found existing nightly release");
-                      } catch (error) {
-                        if (error.status === 404) {
-                          console.log("No existing nightly release found, creating one...");                          
-                          release = await github.rest.repos.createRelease({
-                            owner: context.repo.owner,
-                            repo: context.repo.repo,
-                            tag_name: releaseTag,
-                            name: releaseName,
-                            body: `Nightly build created on ${today} from the latest main branch\nLast commit: ${context.sha}\nCommit message: ${process.env.COMMIT_MESSAGE || "No commit message available"}`,
-                            prerelease: true
-                          });
-                          release = release.data;
-                        } else {
-                          throw error;
-                        }
-                      }
-                        // Handle the case where we have an existing release
-                      // The release object structure differs depending on whether it came from getReleaseByTag or createRelease
-                      const releaseId = release.data ? release.data.id : release.id;
-                      
-                      if (releaseId) {
-                        // Update existing release
-                        console.log("Updating existing nightly release...");
-                        const updateResult = await github.rest.repos.updateRelease({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          release_id: releaseId,
-                          name: releaseName,
-                          body: `Nightly build updated on ${today} from the latest main branch.\nLast commit: ${context.sha}\nCommit message: ${process.env.COMMIT_MESSAGE || "No commit message available"}`,
-                          prerelease: true
-                        });
-                        release = updateResult.data;
-                      }
-                        // Delete existing assets to replace them with new ones
-                      if (release.assets && release.assets.length > 0) {
-                        console.log("Deleting existing release assets...");
-                        for (const asset of release.assets) {
-                          await github.rest.repos.deleteReleaseAsset({
-                            owner: context.repo.owner,
-                            repo: context.repo.repo,
-                            asset_id: asset.id
-                          });
-                        }
-                      }
-                        // Upload new artifacts
-                      console.log("Uploading new artifacts...");
-                      const artifactsDir = 'artifacts';
-                      const platforms = ['macos-latest', 'ubuntu-22.04', 'windows-latest'];
-                      const mime = require('mime-types');
-                      
-                      for (const platform of platforms) {
-                        const platformDir = path.join(artifactsDir, `Blink-${platform}-dev${context.sha}`);
-                        
-                        if (!fs.existsSync(platformDir)) {
-                          console.log(`No artifacts found for ${platform}`);
-                          continue;
-                        }
-                        
-                        const files = fs.readdirSync(platformDir, { recursive: true });
-                        for (const file of files) {
-                          if (typeof file === 'string' && !fs.statSync(path.join(platformDir, file)).isDirectory()) {
-                            const filePath = path.join(platformDir, file);
-                            const fileName = path.basename(filePath);
-                            const contentType = mime.lookup(fileName) || 'application/octet-stream';
-                            
-                            console.log(`Uploading ${fileName} from ${platform}...`);
-                            
-                            // Use Octokit's uploadReleaseAsset with proper content type for binary data                            
-                            await github.rest.repos.uploadReleaseAsset({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              release_id: release.id,
-                              name: `${platform.replace(/-/g, '_')}-${fileName}`,
-                              data: fs.readFileSync(filePath),
-                              headers: {
-                                'content-type': contentType,
-                                'content-length': fs.statSync(filePath).size
-                              }
-                            });
-                          }
-                        }
-                      }
-                      
-                      console.log("Nightly release updated successfully!");
+                      **Last commit:** ${{ github.event.head_commit.message }}
+                      **SHA:** ${{ github.sha }}
+                    prerelease: true
+                    files: release_assets/*
+                    fail_on_unmatched_files: true
+


### PR DESCRIPTION
This pull request streamlines and modernizes the nightly release process in the GitHub Actions workflow. It upgrades key actions to their latest versions, removes a custom Node.js script for release management, and replaces it with a simpler, more maintainable approach using standard GitHub Actions. The process for preparing and uploading release assets is also automated and improved.

**Workflow modernization and simplification:**

* Upgraded `actions/checkout` and `actions/download-artifact` to their latest major versions (`v6.0.1` and `v7.0.0` respectively), ensuring better performance and security.
* Removed the custom Node.js script for creating/updating nightly releases and replaced it with the `softprops/action-gh-release` action, greatly simplifying release management.

**Asset preparation and release automation:**

* Added a new step to prepare release assets by extracting platform information from artifact names and renaming files accordingly, improving asset organization.
* Added a step to delete any existing nightly release before creating a new one, ensuring a clean state for each nightly build.
* Automated the creation of the nightly release, including attaching prepared assets and populating the release notes with commit details, using the `softprops/action-gh-release` action.