### PR TITLE
feat: add Windows ARM64 build support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
           strategy:
                fail-fast: false
                matrix:
-                    platform: [macos-latest, ubuntu-22.04, windows-latest]
+                    platform: [macos-latest, ubuntu-22.04, windows-latest, windows-11-arm]
           runs-on: ${{ matrix.platform }}
           environment: TAURI
           steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
           strategy:
                fail-fast: false
                matrix:
-                    platform: [macos-latest, ubuntu-22.04, windows-latest]
+                    platform: [macos-latest, ubuntu-22.04, windows-latest, windows-11-arm]
           runs-on: ${{ matrix.platform }}
           environment: TAURI
           steps:


### PR DESCRIPTION
## Summary

Adds the `windows-11-arm` GitHub runner to the CI and release workflow matrices so Blink produces native ARM64 Windows installers.

No code changes are needed. Tauri, all the plugins, and the WASM-based media handling are all architecture-neutral, so it's just a workflow change.

Uses GitHub's partner ARM64 runner from Arm Limited (https://github.com/actions/partner-runner-images), which is free for public repos.

Closes #634

## What changed

- `continuous-integration.yml`: added `windows-11-arm` to the build matrix
- `release.yml`: added `windows-11-arm` to the build matrix

The existing conditional logic for ubuntu (apt deps) and macOS (universal binary target) already skips correctly for the new runner, so no extra conditionals were needed.

## Tested

I tested this on my fork and the build succeeds on the ARM64 runner. Rust compiles fine, Tauri bundles the `arm64-setup.exe` installer without issues. Full CI run here: https://github.com/Molier/Blink/actions/runs/24312852588